### PR TITLE
Update gitignore & change mem.alloc to make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ game/shader.glsl_wgsl_vs.spv
 atlas.png
 game/shader.odin
 font.png
+ols.json


### PR DESCRIPTION
Add `ols.json` (the lsp's config file) to the `.gitignore`. 
Change mem.alloc to make as it's preferred:
- temp atlas: slices are preferred over & made to replace pointer offsetting/arithmetic + bounds checking is nice.
- font bitmap: might as well make a mulitpointer. it'll auto cast to a rawptr if need be.

When slicing up the images to add the atlas `copy` will copy the min length of dst & src.
I'll leave it up to you but `make` does return an optional error to be handled. It'll crash if unhandled, which it's a bad thing.

The allocation changes aren't really needed. It more's to do it how it's preferred to be done in Odin. Or more specifically how `core` does things. 
Plus as a tutorial repo make + slices are easier (& safer) than raw dogging pointers.